### PR TITLE
nm2noll addition

### DIFF
--- a/zernike/__init__.py
+++ b/zernike/__init__.py
@@ -144,25 +144,11 @@ class Zern(ABC):
         self.rhotab[0, n] = 1.0
         self.coefnorm[0] = 1.0
 
-        count = 1
         for ni in range(1, n + 1):
-            mi = ni % 2
-            while mi <= ni:
-                if mi == 0:
-                    self._make_rhotab_row(count, ni, mi)
-                    ntab[count], mtab[count] = ni, mi
-                    count += 1
-                else:
-                    self._make_rhotab_row(count + 0, ni, mi)
-                    self._make_rhotab_row(count + 1, ni, mi)
-                    if count % 2:
-                        ntab[count + 0], mtab[count + 0] = ni, mi
-                        ntab[count + 1], mtab[count + 1] = ni, -mi
-                    else:
-                        ntab[count + 0], mtab[count + 0] = ni, -mi
-                        ntab[count + 1], mtab[count + 1] = ni, mi
-                    count += 2
-                mi += 2
+            for mi in range(-ni, ni + 1, 2):
+                k = self.nm2noll(ni, mi) - 1
+                self._make_rhotab_row(k, ni, abs(mi))
+                ntab[k], mtab[k] = ni, mi
 
         # make rhoitab
         for ci in range(nk):
@@ -279,6 +265,19 @@ class Zern(ABC):
 
         """
         return sum([a[j] * self.Zk(j, rho, theta) for j in range(self.nk)])
+
+    @staticmethod
+    def nm2noll(n, m):
+        """Convert indices `(n, m)` to the Noll's index `k`.
+
+        Note that Noll's index `k` starts from one and Python indexing is
+        zero-based.
+
+        """
+        k = n * (n + 1) // 2 + abs(m)
+        if (m <= 0 and n % 4 in (0, 1)) or (m >= 0 and n % 4 in (2, 3)):
+            k += 1
+        return k
 
     def noll2nm(self, k):
         """Convert Noll's index `k` to the indices `(n, m)`.

--- a/zernike/test.py
+++ b/zernike/test.py
@@ -48,6 +48,13 @@ class TestZern(unittest.TestCase):
         expect = np.array([0, 1, -1, 0, -2, 2, -1, 1, -3, 3, 0, 2, -2, 4, -4])
         self.assertTrue(norm(self.pupil.mtab - expect) < self.max_enorm)
 
+    def test_nm2noll(self):
+        noll_indices = ((0, 0), (1, 1), (1, -1), (2, 0), (2, -2), (2, 2),
+                        (3, -1), (3, 1), (3, -3), (3, 3), (4, 0), (4, 2),
+                        (4, -2), (4, 4), (4, -4))
+        for k, (n, m) in enumerate(noll_indices):
+            self.assertEqual(RZern.nm2noll(n, m), k + 1)
+
     def test_rhotab(self):
         expect = [
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13.416407864999, 12.649110640674,


### PR DESCRIPTION
Hello!

Thank you for sharing this code.

# Goal
This pull request is just meant to improve code readability. In the `rhotab` creation part I introduced a function that converts a `(n, m)` indices pair into a Noll's index `k`. The explicit definition of such a function makes your code much shorter and clearer, in my opinion.

Following the convention in `noll2nm`, I made the indices start at 1, in order to keep the code consistent, so that `noll2nm(nm2noll(k)) = k` for any `k >= 1`

# Old tests
The previous tests and this new test succesfully pass on the following configurations:
- [x] Python 3.9 on Windows
- [x] Python 3.8 on Linux in Windows Subsystem for Linux
I didn't run any tests with Python 2.

# New tests
I added one test to assert correctness for this new function up to the 4th radial order. No need to test above the 4th radial order since the ordering only depends on n modulo 4.

Don't hesitate to ask if you have any issue.