### PR TITLE
Pyramid rewrite

### DIFF
--- a/zernike/pyramid.py
+++ b/zernike/pyramid.py
@@ -17,11 +17,13 @@
 # along with zernike.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
-
 import matplotlib.pyplot as plt
+import matplotlib
 import numpy as np
+from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
 from zernike import RZern
+matplotlib.rcParams['mathtext.fontset'] = 'cm'
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -36,89 +38,47 @@ if __name__ == '__main__':
     plt.close('all')
 
     fs = 7
-    fs1 = 6
+    inset_width = 0.9
+    inset_height = 0.9
 
     nradial = args.max_radial_order
     cart = RZern(nradial)
-    L, K = 300, 300
+    L, K = 100, 100
     ddx = np.linspace(-1.0, 1.0, K)
     ddy = np.linspace(-1.0, 1.0, L)
     xv, yv = np.meshgrid(ddx, ddy)
     cart.make_cart_grid(xv, yv)
     c = np.zeros(cart.nk)
-    ns = np.unique(cart.ntab)
 
-    fig = plt.figure(1)
+    fig, ax = plt.subplots()
+    ax.set(xlim=(-nradial - 1, nradial + 1), ylim=(nradial + 0.5, 0))
+    ax.set_xlabel('$m$')
+    ax.set_ylabel('$n$')
 
-    span = 0.05
-    leftoff = .03
-    while nradial >= 0:
-        nk = (nradial + 1) * (nradial + 2) // 2
-        nrows = nradial + 1
-        ncols = np.where(cart.ntab == nradial)[0].size
-        height1 = (1 - (nrows + 1) * span) / nrows
-        width1 = (1 - (ncols + 1) * span) / ncols
-        min1 = min(width1, height1)
-        if min1 > 0:
-            height1 = min1
-            width1 = min1
-            width_span = (1 - min1 * ncols) / (ncols + 1)
-            height_span = (1 - min1 * nrows) / (nrows + 1)
-            break
-        else:
-            nradial -= 1
+    # Styling: no frame, no ticks, tex rendered tick labels.
+    ax.set_frame_on(False)
+    ax.tick_params(left=False, bottom=False)
+    ax.xaxis.set_major_formatter('${x:n}$')
+    ax.yaxis.set_major_formatter('${x:n}$')
 
-    for i in range(nradial + 1):
-        n = ns[i]
-        inds = np.where(cart.ntab == n)[0]
-        ms = cart.mtab[inds]
-        inds = inds[ms.argsort()]
+    for k in range(1, cart.nk + 1):
+        # Plot the phase for the `k`-th Zernike polynomial and add a label
+        # next to it.
+        n, m = cart.noll2nm(k)
+        left = m - inset_width / 2
+        bottom = n - inset_height / 2
+        # Create inset in data coordinates using ax.transData as transform
+        axins = inset_axes(ax, width="100%", height="100%",
+                           bbox_to_anchor=(left, bottom, inset_width,
+                                           inset_height),
+                           bbox_transform=ax.transData, borderpad=0)
 
-        left = (1 - inds.size * width1 - (inds.size - 1) * width_span) / 2
-        bott = (1 - nrows * height1 - (nrows - 1) * height_span) / 2
+        c *= 0.0
+        c[k - 1] = 1.0
+        Phi = cart.eval_grid(c, matrix=True)
+        axins.imshow(Phi, origin='lower', extent=[0, 1, 0, 1])
+        axins.axis('off')
 
-        bt = (bott + (nrows - i - 1) * (height1 + height_span))
-
-        for j in range(inds.size):
-            lf = left + j * (width1 + width_span) + leftoff
-            ax = fig.add_axes([lf, bt, width1, height1])
-
-            c *= 0.0
-            c[inds[j]] = 1.0
-            Phi = cart.eval_grid(c, matrix=True)
-            ax.imshow(Phi, origin='lower', extent=[0, 1, 0, 1])
-            ax.axis('off')
-
-            ze = inds[j] + 1
-            zn = cart.ntab[inds[j]]
-            zm = cart.mtab[inds[j]]
-
-            ax.text(1,
-                    1,
-                    '$\\#' + str(ze) + '$',
-                    transform=ax.transAxes,
-                    fontsize=fs1)
-
-        plt.text(0,
-                 bt + height1 / 2,
-                 '$' + str(zn) + '$',
-                 transform=fig.transFigure,
-                 fontsize=fs)
-
-    plt.text(0, 1, '$n$', transform=fig.transFigure, va='top', fontsize=fs)
-    plt.text(0, 0, '$m$', transform=fig.transFigure, va='bottom', fontsize=fs)
-
-    ms = np.arange(-nradial, nradial + 1)
-    left = (1 - inds.size * width1 - (inds.size - 1) * width_span) / 2
-    left += leftoff + width1 / 2
-    for i in range(2 * ncols - 1):
-        plt.text(left,
-                 0,
-                 '$' + str(ms[i]) + '$',
-                 transform=fig.transFigure,
-                 ha='center',
-                 va='bottom',
-                 fontsize=fs)
-        left += (width1 + width_span) / 2
+        axins.text(0.9, 0.9, '$\\#' + str(k) + '$', fontsize=fs)
 
     plt.show()


### PR DESCRIPTION
Hello again!

# Rewrite of the pyramid example
When I looked at the code in `pyramid.py`, I saw you struggled with the arguments of the `fig.add_axes` function. Because the dimensions [left, bottom, width, height] of the new axes are in fractions of figure width and height. Your code performs complex calculations for determining the proper values of left, bottom, width and height.
What if we could position the inset images of the zernike polynomials directly at their right position `(m, n)`?
Using the function `inset_axes`, it is possible to use an absolute position instead of a position relative to the main figure. This massively simplifes your code.
You can learn more about the `inset_axes` function [here](https://matplotlib.org/stable/gallery/axes_grid1/inset_locator_demo.html)

# Pyramid image
![pyramid_zernike](https://user-images.githubusercontent.com/60904290/124381754-7c2da900-dcc4-11eb-942f-ef41794103c3.png)

